### PR TITLE
Update bedrock.py to allow url_override and set other kwargs

### DIFF
--- a/utils/bedrock.py
+++ b/utils/bedrock.py
@@ -72,7 +72,8 @@ def get_bedrock_client(
 
     bedrock_client = session.client(
         service_name="bedrock",
-        config=retry_config
+        config=retry_config,
+        **boto3_kwargs
         )
 
     print("boto3 Bedrock client successfully created!")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allows user to set the overriden bedrock endpoint url while creating a bedrock session along with necessary creds set in kwargs in `get_bedrock_client`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
