### PR TITLE
Update bedrock_boto3_setup.ipynb

### DIFF
--- a/01_Intro/bedrock_boto3_setup.ipynb
+++ b/01_Intro/bedrock_boto3_setup.ipynb
@@ -492,6 +492,7 @@
    "outputs": [],
    "source": [
     "# ---- ⚠️ Un-comment and edit the below lines as needed for your AWS setup ⚠️ ----\n",
+    "# import os\n",
     "\n",
     "# os.environ[\"AWS_DEFAULT_REGION\"] = \"<REGION_NAME>\"  # E.g. \"us-east-1\"\n",
     "# os.environ[\"AWS_PROFILE\"] = \"<YOUR_PROFILE>\"\n",


### PR DESCRIPTION
added "import os" in case the os.environ is used

*Issue #, if available:*
if the os.environ is used the os won't be available unless imported

*Description of changes:*
the change will import os

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
